### PR TITLE
fix: Add eq UUID to filters

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -21,13 +21,14 @@ type Base struct {
 type User struct {
 	Base
 
-	Firstname   string `json:"firstname"`
-	Lastname    string `json:"lastname"`
-	Email       string `json:"email"`
-	UserName    string `gorm:"column:display_name" json:"userName"`
-	PersonSex   string `json:"gender"`
-	Age         uint   `json:"age"`
-	Contributor bool   `json:"contributor"`
+	Firstname   string    `json:"firstname"`
+	Lastname    string    `json:"lastname"`
+	Email       string    `json:"email"`
+	UserName    string    `gorm:"column:display_name" json:"userName"`
+	PersonSex   string    `json:"gender"`
+	Age         uint      `json:"age"`
+	Contributor bool      `json:"contributor"`
+	PersonId    uuid.UUID `json:"personId"`
 }
 
 func TestMain(m *testing.M) {
@@ -305,6 +306,22 @@ func Test_QueryWithFilterEquals(t *testing.T) {
 
 	expectedSql := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
 		return tx.Model(&User{}).Where("LOWER(firstname) = LOWER('goat')").Find(&[]User{})
+	})
+
+	assert.Equal(t, expectedSql, sql)
+}
+
+func Test_QueryWithFilterEqualsUUID(t *testing.T) {
+	id := uuid.New()
+	query := Query{Filter: fmt.Sprintf("personId eq '%s'", id)}
+
+	sql := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		res, _, _ := Apply(tx.Model(&User{}), query, nil, nil, &[]User{})
+		return res.Find(&[]User{})
+	})
+
+	expectedSql := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		return tx.Model(&User{}).Where(fmt.Sprintf("person_id = '%s'", id)).Find(&[]User{})
 	})
 
 	assert.Equal(t, expectedSql, sql)


### PR DESCRIPTION
Fixes https://github.com/goatquery/goatquery-go/issues/33

This pull request includes changes to support filtering by UUID in the `app.go` and `app_test.go` files. The most important changes include adding the `uuid` package, modifying the filtering logic to handle UUIDs, and updating the test cases accordingly.

Enhancements to UUID support:

* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR8): Added the `uuid` package to the import statements.
* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL56-R65): Modified the `Apply` function to include a case for handling UUIDs in the filtering logic.

Updates to test cases:

* [`app_test.go`](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eR31): Added a `personId` field of type `uuid.UUID` to the `User` struct.
* [`app_test.go`](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eR314-R329): Added a new test function `Test_QueryWithFilterEqualsUUID` to verify filtering by UUID.