### PR TITLE
fix: missed an ok

### DIFF
--- a/app.go
+++ b/app.go
@@ -60,7 +60,7 @@ func Apply(db *gorm.DB, query Query, maxTop *int, searchFunc func(db *gorm.DB, s
 			case strings.EqualFold(operand, "contains"):
 				valueWithoutQuotes := getValueBetweenQuotes(value)
 				where.WriteString(fmt.Sprintf("%s %s '%%%s%%'", property, filterOperations[operand], valueWithoutQuotes))
-			case field.Type == reflect.TypeOf(uuid.UUID{}):
+			case ok && field.Type == reflect.TypeOf(uuid.UUID{}):
 				where.WriteString(fmt.Sprintf("%s %s %s", property, filterOperations[operand], value))
 			default:
 				where.WriteString(fmt.Sprintf("LOWER(%s) %s LOWER(%s)", property, filterOperations[operand], value))


### PR DESCRIPTION
trust me bro

This pull request includes a small change to the `Apply` function in the `app.go` file. The change ensures that the `field.Type` check for `uuid.UUID` is only performed if the `ok` variable is true. This adds a necessary condition to prevent potential errors when `ok` is false.

Changes in `func Apply(db *gorm.DB, query Query, maxTop *int, searchFunc func(db *gorm.DB, s` in file `app.go`:

* Added a condition to check if `ok` is true before checking if `field.Type` is `uuid.UUID`.